### PR TITLE
Source column in parquet file using ecosounds link

### DIFF
--- a/src/baw_utils.py
+++ b/src/baw_utils.py
@@ -1,0 +1,68 @@
+import re
+import urllib
+from pathlib import Path
+
+FILE_ID_TO_UID_PATTERN = re.compile(r".*_(\d+).[^\.]+$")
+
+default_baw_domain = "api.ecosounds.org"
+
+
+def parse_canonical_filename(
+    filename: str
+) -> str:
+  """Construct an baw audio URL."""
+  # Extract the recording UID. Example:
+  # 'site_0277/20210428T100000+1000_Five-Rivers-Dry-A_909057.flac' -> 909057
+  # 'site_0277/20210428T100000+1000_Five-Rivers-Dry-A_909057.wav' -> 909057
+
+  # get the basename
+  filename = Path(filename).name
+
+  # split by underscore
+  parts = filename.split("_")
+
+  if len(parts) < 2:
+    return None
+
+  # the first part is the timestamp
+  timestamp = parts[0]
+
+  # the last part is the file id and extension
+  arid, ext = tuple(parts[-1].split("."))
+
+  # everything inbetween is the site name
+  site = "_".join(parts[1:-1])
+
+  return {
+    "site": site,
+    "timestamp": timestamp,
+    "arid": arid,
+    "ext": ext
+  }
+
+
+def original_recording_url(
+    arid,
+    baw_domain=default_baw_domain
+):
+  """Construct an baw audio URL."""
+  return f"https://{baw_domain}/audio_recordings/{arid}/original"
+
+
+def recording_url_from_filename(
+    filename: str,
+    baw_domain=default_baw_domain
+):
+  """
+  Construct an baw audio URL.
+  filename: str: the filename of the audio recording in the format timestamp_site_arid.ext
+  baw_domain: str: the domain of the BAW API
+  If the filename is not in the correct format, the original filename is returned.  
+  """
+
+  result = parse_canonical_filename(filename)
+  if result is None:
+    return filename
+  else:
+    return original_recording_url(result["arid"], baw_domain=baw_domain)
+

--- a/src/embed_audio_slim.py
+++ b/src/embed_audio_slim.py
@@ -20,7 +20,8 @@ from ml_collections import config_dict
 
 from chirp.inference.models import TaxonomyModelTF
 
-from src import data_frames 
+from src import data_frames
+from src import baw_utils 
 
 def merge_defaults(config: config_dict):
   """
@@ -61,7 +62,7 @@ def embed_folder(source_folder, output_folder, config: config_dict = None) -> No
 def embed_file_and_save(source: str, destination: str, config: config_dict = None) -> None:
     """
     embeds a single file and saves to destination
-    source can be either a filename or a folder. If it's a folder that exists, the original basename is used with parquet extension
+    destination can be either a filename or a folder. If it's a folder that exists, the original basename is used with parquet extension
     """
 
     source = Path(source)
@@ -75,7 +76,15 @@ def embed_file_and_save(source: str, destination: str, config: config_dict = Non
 
 
     embeddings = embed_one_file(source, config)
+    source = baw_utils.recording_url_from_filename(source)
     save_embeddings(embeddings, destination, source)
+
+
+def parse_source(source: str, baw_host='api.ecosounds.org') -> str:
+    """
+    returns a string that is the source of the embeddings
+    """
+    return str(source)
 
 
 def embed_one_file(source: str, config: config_dict = None) -> np.array:

--- a/tests/app_tests/test_baw_utils.py
+++ b/tests/app_tests/test_baw_utils.py
@@ -1,0 +1,70 @@
+from src import baw_utils
+
+def test_parse_canonical_filename():
+    """
+    Tests various paths for the parse_canonical_filename function
+    """
+
+    filename = 'site_0277/20210428T100000+1000_Five-Rivers-Dry-A_909057.flac'
+    result = baw_utils.parse_canonical_filename(filename)
+    assert result['arid'] == "909057"
+    assert result['site'] == "Five-Rivers-Dry-A"
+    assert result['timestamp'] == "20210428T100000+1000"
+    assert result['ext'] == "flac"
+
+    filename = '20210428T100000+1000_Five-Rivers-Dry-A_909057.flac'
+    result = baw_utils.parse_canonical_filename(filename)
+    assert result['arid'] == "909057"
+    assert result['site'] == "Five-Rivers-Dry-A"
+    assert result['timestamp'] == "20210428T100000+1000"
+    assert result['ext'] == "flac"
+
+    filename = 'folder_with_underscores/a_b/20210428T100000Z_Five-Rivers-Dry-A_909057.wav'
+    result = baw_utils.parse_canonical_filename(filename)
+    assert result['timestamp'] == "20210428T100000Z"
+    assert result['ext'] == "wav"
+
+
+    filename = '20210428T100000Z_Five_Rivers_Dry_A_12345.wav'
+    result = baw_utils.parse_canonical_filename(filename)
+    assert result['arid'] == "12345"
+    assert result['site'] == "Five_Rivers_Dry_A"
+    assert result['timestamp'] == "20210428T100000Z"
+    assert result['ext'] == "wav"
+
+
+
+def test_original_recording_url():
+    """
+    Tests various paths for the original_recording_url function
+    """
+
+    arid = "12345"
+    result = baw_utils.original_recording_url(arid)
+    assert result == "https://api.ecosounds.org/audio_recordings/12345/original"
+
+    arid = "54321"
+    result = baw_utils.original_recording_url(arid, "api.acousticobservatory.org")
+    assert result == "https://api.acousticobservatory.org/audio_recordings/54321/original"
+
+
+def test_recording_url_from_filename():
+    """
+    Tests various paths for the recording_url_from_filename function
+    """
+
+    filename = 'site_0277/20210428T100000+1000_Five-Rivers-Dry-A_909057.flac'
+    result = baw_utils.recording_url_from_filename(filename)
+    assert result == "https://api.ecosounds.org/audio_recordings/909057/original"
+
+    filename = '20210428T100000+1000_Five-Rivers-Dry-A_909057.flac'
+    result = baw_utils.recording_url_from_filename(filename)
+    assert result == "https://api.ecosounds.org/audio_recordings/909057/original"
+
+    filename = 'folder_with_underscores/a_b/20210428T100000Z_Five-Rivers-Dry-A_909057.wav'
+    result = baw_utils.recording_url_from_filename(filename, "api.acousticobservatory.org")
+    assert result == "https://api.acousticobservatory.org/audio_recordings/909057/original"
+
+    filename = '20210428T100000Z_Five_Rivers_Dry_A_12345.wav'
+    result = baw_utils.recording_url_from_filename(filename, "api.acousticobservatory.org")
+    assert result == "https://api.acousticobservatory.org/audio_recordings/12345/original"

--- a/tests/app_tests/test_embed.py
+++ b/tests/app_tests/test_embed.py
@@ -25,13 +25,24 @@ def test_embed_one_file():
 
 
 def test_embed_file_in_file_out():
-    
-    source = "tests/files/audio/100sec.wav"
+    """
+    Tests embedding and saving to a specified parquet filename
+    Also tests that the canonical filename is parsed correctly
+    """
+
+    original_source = "tests/files/audio/100sec.wav"
+    source = "tests/input/20240101T123456Z_my-amazing-site_2468.wav"
+    shutil.copy(original_source, source)
     destination = "tests/output/100sec_embeddings.parquet"
 
     embed_audio_slim.embed_file_and_save(source, destination)
 
     assert os.path.exists(destination)
+
+    # now read the embeddings back and check the shape and source columns are as expected
+    df = pd.read_parquet(destination)
+    assert df.shape == (20, 1283)
+    assert df.source[0] == "https://api.ecosounds.org/audio_recordings/2468/original"
 
 
 def test_embed_file_in_folder_out():


### PR DESCRIPTION
Baw utils added to parse canonical filename to retrieve the audio recording id, which is then used to generate an original audio recording url, which is used in the source. 

The baw_utils accepts the baw instance hostname as an argument, and is configured to default to api.ecosounds.org if it's not supplied.  (currently this is not configurable but will be in the future #13) 